### PR TITLE
py3.7.0

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.1
+python-3.7.0


### PR DESCRIPTION
failed to build uwsgi in heroku python 3.7.1
```
-----> Python app detected
-----> Found python-3.6.5, removing
-----> Installing python-3.7.1
-----> Installing pip
-----> Installing requirements with pip
       Collecting Django==2.1.4 (from -r /tmp/build_869a30dea6eca0cdd413d8908d04c238/requirements.txt (line 1))
         Downloading https://files.pythonhosted.org/packages/fd/9a/0c028ea0fe4f5803dda1a7afabeed958d0c8b79b0fe762ffbf728db3b90d/Django-2.1.4-py3-none-any.whl (7.3MB)
       Collecting pytz==2018.7 (from -r /tmp/build_869a30dea6eca0cdd413d8908d04c238/requirements.txt (line 2))
         Downloading https://files.pythonhosted.org/packages/f8/0e/2365ddc010afb3d79147f1dd544e5ee24bf4ece58ab99b16fbb465ce6dc0/pytz-2018.7-py2.py3-none-any.whl (506kB)
       Collecting uWSGI==2.0.17.1 (from -r /tmp/build_869a30dea6eca0cdd413d8908d04c238/requirements.txt (line 3))
         Downloading https://files.pythonhosted.org/packages/a2/c9/a2d5737f63cd9df4317a4acc15d1ddf4952e28398601d8d7d706c16381e0/uwsgi-2.0.17.1.tar.gz (800kB)
       Installing collected packages: pytz, Django, uWSGI
         Running setup.py install for uWSGI: started
           Running setup.py install for uWSGI: finished with status 'error'
           Complete output from command /app/.heroku/python/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-5rqpa5d9/uWSGI/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-y9w4kurf-record/install-record.txt --single-version-externally-managed --compile:
           /app/.heroku/python/lib/python3.7/distutils/dist.py:274: UserWarning: Unknown distribution option: 'descriptions'
             warnings.warn(msg)
           running install
           using profile: buildconf/default.ini
           detected include path: ['/app/.heroku/python/include', '.', '/usr/lib/gcc/x86_64-linux-gnu/7/include', '/usr/local/include', '/usr/lib/gcc/x86_64-linux-gnu/7/include-fixed', '/usr/include/x86_64-linux-gnu', '/usr/include']
           Patching "bin_name" to properly install_scripts dir
           detected CPU cores: 2
           configured CFLAGS: -O2 -I. -Wall -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -DUWSGI_HAS_IFADDRS -DUWSGI_ZLIB -DUWSGI_LOCK_USE_MUTEX -DUWSGI_EVENT_USE_EPOLL -DUWSGI_EVENT_TIMER_USE_TIMERFD -DUWSGI_EVENT_FILEMONITOR_USE_INOTIFY  -DUWSGI_PCRE -DUWSGI_ROUTING -DUWSGI_CAP -DUWSGI_VERSION="\"2.0.17.1\"" -DUWSGI_VERSION_BASE="2" -DUWSGI_VERSION_MAJOR="0" -DUWSGI_VERSION_MINOR="17" -DUWSGI_VERSION_REVISION="1" -DUWSGI_VERSION_CUSTOM="\"\"" -DUWSGI_YAML -DUWSGI_SSL -I/usr/include/libxml2 -DUWSGI_XML -DUWSGI_XML_LIBXML2 -DUWSGI_PLUGIN_DIR="\".\"" -DUWSGI_DECLARE_EMBEDDED_PLUGINS="UDEP(python);UDEP(gevent);UDEP(ping);UDEP(cache);UDEP(nagios);UDEP(rrdtool);UDEP(carbon);UDEP(rpc);UDEP(corerouter);UDEP(fastrouter);UDEP(http);UDEP(ugreen);UDEP(signal);UDEP(syslog);UDEP(rsyslog);UDEP(logsocket);UDEP(router_uwsgi);UDEP(router_redirect);UDEP(router_basicauth);UDEP(zergpool);UDEP(redislog);UDEP(mongodblog);UDEP(router_rewrite);UDEP(router_http);UDEP(logfile);UDEP(router_cache);UDEP(rawrouter);UDEP(router_static);UDEP(sslrouter);UDEP(spooler);UDEP(cheaper_busyness);UDEP(symcall);UDEP(transformation_tofile);UDEP(transformation_gzip);UDEP(transformation_chunked);UDEP(transformation_offload);UDEP(router_memcached);UDEP(router_redis);UDEP(router_hash);UDEP(router_expires);UDEP(router_metrics);UDEP(transformation_template);UDEP(stats_pusher_socket);" -DUWSGI_LOAD_EMBEDDED_PLUGINS="ULEP(python);ULEP(gevent);ULEP(ping);ULEP(cache);ULEP(nagios);ULEP(rrdtool);ULEP(carbon);ULEP(rpc);ULEP(corerouter);ULEP(fastrouter);ULEP(http);ULEP(ugreen);ULEP(signal);ULEP(syslog);ULEP(rsyslog);ULEP(logsocket);ULEP(router_uwsgi);ULEP(router_redirect);ULEP(router_basicauth);ULEP(zergpool);ULEP(redislog);ULEP(mongodblog);ULEP(router_rewrite);ULEP(router_http);ULEP(logfile);ULEP(router_cache);ULEP(rawrouter);ULEP(router_static);ULEP(sslrouter);ULEP(spooler);ULEP(cheaper_busyness);ULEP(symcall);ULEP(transformation_tofile);ULEP(transformation_gzip);ULEP(transformation_chunked);ULEP(transformation_offload);ULEP(router_memcached);ULEP(router_redis);ULEP(router_hash);ULEP(router_expires);ULEP(router_metrics);ULEP(transformation_template);ULEP(stats_pusher_socket);"
           *** uWSGI compiling server core ***
           [thread 1][gcc -pthread] core/utils.o
           [thread 0][gcc -pthread] core/protocol.o
           [thread 0][gcc -pthread] core/socket.o
           [thread 0][gcc -pthread] core/logging.o
           [thread 1][gcc -pthread] core/master.o
           [thread 1][gcc -pthread] core/master_utils.o
           [thread 0][gcc -pthread] core/emperor.o
           [thread 1][gcc -pthread] core/notify.o
           [thread 0][gcc -pthread] core/mule.o
           [thread 1][gcc -pthread] core/subscription.o
           [thread 0][gcc -pthread] core/stats.o
           [thread 1][gcc -pthread] core/sendfile.o
           [thread 0][gcc -pthread] core/async.o
           [thread 1][gcc -pthread] core/master_checks.o
           [thread 0][gcc -pthread] core/fifo.o
           [thread 1][gcc -pthread] core/offload.o
           [thread 0][gcc -pthread] core/io.o
           [thread 1][gcc -pthread] core/static.o
           [thread 1][gcc -pthread] core/websockets.o
           [thread 0][gcc -pthread] core/spooler.o
           [thread 1][gcc -pthread] core/snmp.o
           [thread 0][gcc -pthread] core/exceptions.o
           [thread 1][gcc -pthread] core/config.o
           [thread 0][gcc -pthread] core/setup_utils.o
           [thread 0][gcc -pthread] core/clock.o
           [thread 1][gcc -pthread] core/init.o
           [thread 0][gcc -pthread] core/buffer.o
           [thread 1][gcc -pthread] core/reader.o
           [thread 0][gcc -pthread] core/writer.o
           [thread 1][gcc -pthread] core/alarm.o
           [thread 0][gcc -pthread] core/cron.o
           [thread 1][gcc -pthread] core/hooks.o
           [thread 0][gcc -pthread] core/plugins.o
           [thread 1][gcc -pthread] core/lock.o
           [thread 0][gcc -pthread] core/cache.o
           [thread 1][gcc -pthread] core/daemons.o
           [thread 1][gcc -pthread] core/errors.o
           [thread 0][gcc -pthread] core/hash.o
           [thread 1][gcc -pthread] core/master_events.o
           [thread 0][gcc -pthread] core/chunked.o
           [thread 1][gcc -pthread] core/queue.o
           [thread 0][gcc -pthread] core/event.o
           [thread 1][gcc -pthread] core/signal.o
           [thread 0][gcc -pthread] core/strings.o
           [thread 1][gcc -pthread] core/progress.o
           [thread 0][gcc -pthread] core/timebomb.o
           [thread 1][gcc -pthread] core/ini.o
           [thread 0][gcc -pthread] core/fsmon.o
           [thread 1][gcc -pthread] core/mount.o
           [thread 0][gcc -pthread] core/metrics.o
           [thread 1][gcc -pthread] core/plugins_builder.o
           [thread 1][gcc -pthread] core/sharedarea.o
           [thread 0][gcc -pthread] core/rpc.o
           [thread 1][gcc -pthread] core/gateway.o
           [thread 0][gcc -pthread] core/loop.o
           [thread 1][gcc -pthread] core/cookie.o
           [thread 0][gcc -pthread] core/querystring.o
           [thread 1][gcc -pthread] core/rb_timers.o
           [thread 0][gcc -pthread] core/transformations.o
           [thread 1][gcc -pthread] core/uwsgi.o
           [thread 0][gcc -pthread] proto/base.o
           [thread 0][gcc -pthread] proto/uwsgi.o
           [thread 0][gcc -pthread] proto/http.o
           [thread 0][gcc -pthread] proto/fastcgi.o
           [thread 0][gcc -pthread] proto/scgi.o
           [thread 1][gcc -pthread] proto/puwsgi.o
           [thread 0][gcc -pthread] lib/linux_ns.o
           [thread 1][gcc -pthread] core/zlib.o
           [thread 0][gcc -pthread] core/regexp.o
           [thread 1][gcc -pthread] core/routing.o
           [thread 0][gcc -pthread] core/yaml.o
           [thread 0][gcc -pthread] core/ssl.o
           [thread 1][gcc -pthread] core/legion.o
           [thread 0][gcc -pthread] core/xmlconf.o
           [thread 0][gcc -pthread] core/dot_h.o
           [thread 0][gcc -pthread] core/config_py.o
           *** uWSGI compiling embedded plugins ***
           [thread 0][gcc -pthread] plugins/python/python_plugin.o
           [thread 1][gcc -pthread] plugins/python/pyutils.o
           [thread 1][gcc -pthread] plugins/python/pyloader.o
           [thread 0][gcc -pthread] plugins/python/wsgi_handlers.o
           [thread 1][gcc -pthread] plugins/python/wsgi_headers.o
           [thread 0][gcc -pthread] plugins/python/wsgi_subhandler.o
           [thread 1][gcc -pthread] plugins/python/web3_subhandler.o
           [thread 0][gcc -pthread] plugins/python/pump_subhandler.o
           [thread 1][gcc -pthread] plugins/python/gil.o
           [thread 0][gcc -pthread] plugins/python/uwsgi_pymodule.o
           [thread 1][gcc -pthread] plugins/python/profiler.o
           [thread 1][gcc -pthread] plugins/python/symimporter.o
           [thread 1][gcc -pthread] plugins/python/tracebacker.o
           [thread 1][gcc -pthread] plugins/python/raw.o
           [thread 0][gcc -pthread] plugins/gevent/gevent.o
           [thread 1][gcc -pthread] plugins/gevent/hooks.o
           [thread 1][gcc -pthread] plugins/ping/ping_plugin.o
           [thread 0][gcc -pthread] plugins/cache/cache.o
           [thread 1][gcc -pthread] plugins/nagios/nagios.o
           [thread 0][gcc -pthread] plugins/rrdtool/rrdtool.o
           [thread 1][gcc -pthread] plugins/carbon/carbon.o
           [thread 0][gcc -pthread] plugins/rpc/rpc_plugin.o
           [thread 1][gcc -pthread] plugins/corerouter/cr_common.o
           [thread 0][gcc -pthread] plugins/corerouter/cr_map.o
           [thread 1][gcc -pthread] plugins/corerouter/corerouter.o
           [thread 0][gcc -pthread] plugins/fastrouter/fastrouter.o
           [thread 1][gcc -pthread] plugins/http/http.o
           [thread 0][gcc -pthread] plugins/http/keepalive.o
           [thread 0][gcc -pthread] plugins/http/https.o
           [thread 1][gcc -pthread] plugins/http/spdy3.o
           [thread 0][gcc -pthread] plugins/ugreen/ugreen.o
           [thread 0][gcc -pthread] plugins/signal/signal_plugin.o
           [thread 1][gcc -pthread] plugins/syslog/syslog_plugin.o
           [thread 0][gcc -pthread] plugins/rsyslog/rsyslog_plugin.o
           [thread 1][gcc -pthread] plugins/logsocket/logsocket_plugin.o
           [thread 0][gcc -pthread] plugins/router_uwsgi/router_uwsgi.o
           [thread 1][gcc -pthread] plugins/router_redirect/router_redirect.o
           [thread 0][gcc -pthread] plugins/router_basicauth/router_basicauth.o
           [thread 1][gcc -pthread] plugins/zergpool/zergpool.o
           [thread 0][gcc -pthread] plugins/redislog/redislog_plugin.o
           [thread 1][gcc -pthread] plugins/mongodblog/mongodblog_plugin.o
           [thread 1][gcc -pthread] plugins/router_rewrite/router_rewrite.o
           [thread 0][gcc -pthread] plugins/router_http/router_http.o
           [thread 1][gcc -pthread] plugins/logfile/logfile.o
           [thread 0][gcc -pthread] plugins/router_cache/router_cache.o
           [thread 1][gcc -pthread] plugins/rawrouter/rawrouter.o
           [thread 0][gcc -pthread] plugins/router_static/router_static.o
           [thread 1][gcc -pthread] plugins/sslrouter/sslrouter.o
           [thread 0][gcc -pthread] plugins/spooler/spooler_plugin.o
           [thread 0][gcc -pthread] plugins/cheaper_busyness/cheaper_busyness.o
           [thread 1][gcc -pthread] plugins/symcall/symcall_plugin.o
           [thread 0][gcc -pthread] plugins/transformation_tofile/tofile.o
           [thread 1][gcc -pthread] plugins/transformation_gzip/gzip.o
           [thread 0][gcc -pthread] plugins/transformation_chunked/chunked.o
           [thread 1][gcc -pthread] plugins/transformation_offload/offload.o
           [thread 0][gcc -pthread] plugins/router_memcached/router_memcached.o
           [thread 1][gcc -pthread] plugins/router_redis/router_redis.o
           [thread 0][gcc -pthread] plugins/router_hash/router_hash.o
           [thread 1][gcc -pthread] plugins/router_expires/expires.o
           [thread 0][gcc -pthread] plugins/router_metrics/plugin.o
           [thread 1][gcc -pthread] plugins/transformation_template/tt.o
           [thread 1][gcc -pthread] plugins/stats_pusher_socket/plugin.o
           *** uWSGI linking ***
           gcc -pthread -o /app/.heroku/python/bin/uwsgi  core/utils.o core/protocol.o core/socket.o core/logging.o core/master.o core/master_utils.o core/emperor.o core/notify.o core/mule.o core/subscription.o core/stats.o core/sendfile.o core/async.o core/master_checks.o core/fifo.o core/offload.o core/io.o core/static.o core/websockets.o core/spooler.o core/snmp.o core/exceptions.o core/config.o core/setup_utils.o core/clock.o core/init.o core/buffer.o core/reader.o core/writer.o core/alarm.o core/cron.o core/hooks.o core/plugins.o core/lock.o core/cache.o core/daemons.o core/errors.o core/hash.o core/master_events.o core/chunked.o core/queue.o core/event.o core/signal.o core/strings.o core/progress.o core/timebomb.o core/ini.o core/fsmon.o core/mount.o core/metrics.o core/plugins_builder.o core/sharedarea.o core/rpc.o core/gateway.o core/loop.o core/cookie.o core/querystring.o core/rb_timers.o core/transformations.o core/uwsgi.o proto/base.o proto/uwsgi.o proto/http.o proto/fastcgi.o proto/scgi.o proto/puwsgi.o lib/linux_ns.o core/zlib.o core/regexp.o core/routing.o core/yaml.o core/ssl.o core/legion.o core/xmlconf.o core/dot_h.o core/config_py.o plugins/python/python_plugin.o plugins/python/pyutils.o plugins/python/pyloader.o plugins/python/wsgi_handlers.o plugins/python/wsgi_headers.o plugins/python/wsgi_subhandler.o plugins/python/web3_subhandler.o plugins/python/pump_subhandler.o plugins/python/gil.o plugins/python/uwsgi_pymodule.o plugins/python/profiler.o plugins/python/symimporter.o plugins/python/tracebacker.o plugins/python/raw.o plugins/gevent/gevent.o plugins/gevent/hooks.o plugins/ping/ping_plugin.o plugins/cache/cache.o plugins/nagios/nagios.o plugins/rrdtool/rrdtool.o plugins/carbon/carbon.o plugins/rpc/rpc_plugin.o plugins/corerouter/cr_common.o plugins/corerouter/cr_map.o plugins/corerouter/corerouter.o plugins/fastrouter/fastrouter.o plugins/http/http.o plugins/http/keepalive.o plugins/http/https.o plugins/http/spdy3.o plugins/ugreen/ugreen.o plugins/signal/signal_plugin.o plugins/syslog/syslog_plugin.o plugins/rsyslog/rsyslog_plugin.o plugins/logsocket/logsocket_plugin.o plugins/router_uwsgi/router_uwsgi.o plugins/router_redirect/router_redirect.o plugins/router_basicauth/router_basicauth.o plugins/zergpool/zergpool.o plugins/redislog/redislog_plugin.o plugins/mongodblog/mongodblog_plugin.o plugins/router_rewrite/router_rewrite.o plugins/router_http/router_http.o plugins/logfile/logfile.o plugins/router_cache/router_cache.o plugins/rawrouter/rawrouter.o plugins/router_static/router_static.o plugins/sslrouter/sslrouter.o plugins/spooler/spooler_plugin.o plugins/cheaper_busyness/cheaper_busyness.o plugins/symcall/symcall_plugin.o plugins/transformation_tofile/tofile.o plugins/transformation_gzip/gzip.o plugins/transformation_chunked/chunked.o plugins/transformation_offload/offload.o plugins/router_memcached/router_memcached.o plugins/router_redis/router_redis.o plugins/router_hash/router_hash.o plugins/router_expires/expires.o plugins/router_metrics/plugin.o plugins/transformation_template/tt.o plugins/stats_pusher_socket/plugin.o -lpthread -lm -rdynamic -ldl -lz -lpcre -lcap -lssl -lcrypto -lxml2 -lpthread -ldl -lutil -lm /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a -lutil -lcrypt
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(abstract.o): relocation R_X86_64_32S against symbol `_Py_NotImplementedStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(boolobject.o): relocation R_X86_64_32S against symbol `_Py_FalseStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(bytearrayobject.o): relocation R_X86_64_32 against symbol `_PyByteArray_empty_string' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(bytesobject.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(call.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(exceptions.o): relocation R_X86_64_32S against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(fileobject.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(floatobject.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(frameobject.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(funcobject.o): relocation R_X86_64_32S against symbol `PyCode_Type' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(iterobject.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(listobject.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(longobject.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(dictobject.o): relocation R_X86_64_32S against `.text.hot' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(memoryobject.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(methodobject.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(moduleobject.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(object.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(obmalloc.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(capsule.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(rangeobject.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(setobject.o): relocation R_X86_64_32S against `.data' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(sliceobject.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(structseq.o): relocation R_X86_64_32 against `.data' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(tupleobject.o): relocation R_X86_64_32 against symbol `_PyEval_SliceIndexNotNone' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(typeobject.o): relocation R_X86_64_32 against `.text' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(unicodeobject.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(unicodectype.o): relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(weakrefobject.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(_warnings.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(bltinmodule.o): relocation R_X86_64_32S against symbol `PyFilter_Type' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(ceval.o): relocation R_X86_64_32 against symbol `_PyRuntime' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(compile.o): relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(codecs.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(errors.o): relocation R_X86_64_32S against symbol `PyTraceBack_Type' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(future.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(getargs.o): relocation R_X86_64_32S against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(getcompiler.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(getversion.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(import.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(importdl.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(marshal.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(modsupport.o): relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(pathconfig.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(peephole.o): relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(pyhash.o): relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(pylifecycle.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(pystate.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(context.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(hamt.o): relocation R_X86_64_32S against symbol `_PyHamt_BitmapNode_Type' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(pythonrun.o): relocation R_X86_64_32 against `.data' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(pytime.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(bootstrap_hash.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(symtable.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(sysmodule.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(thread.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(traceback.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(pystrtod.o): relocation R_X86_64_32S against symbol `_Py_ctype_tolower' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(dtoa.o): relocation R_X86_64_32S against `.bss' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(formatter_unicode.o): relocation R_X86_64_32S against symbol `_Py_ctype_table' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(fileutils.o): relocation R_X86_64_32S against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(dynload_shlib.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(getpath.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(main.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(gcmodule.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(posixmodule.o): relocation R_X86_64_32S against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(errnomodule.o): relocation R_X86_64_32 against `.data' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(pwdmodule.o): relocation R_X86_64_32 against `.bss' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(_sre.o): relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(_codecsmodule.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(_weakref.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(_functoolsmodule.o): relocation R_X86_64_32 against `.data' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(_operator.o): relocation R_X86_64_32 against `.data' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(_collectionsmodule.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(_abc.o): relocation R_X86_64_32 against `.data' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(itertoolsmodule.o): relocation R_X86_64_32S against `.data' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(atexitmodule.o): relocation R_X86_64_32 against `.text' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(signalmodule.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(_stat.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(timemodule.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(_threadmodule.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(_localemodule.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(_iomodule.o): relocation R_X86_64_32 against `.data' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(iobase.o): relocation R_X86_64_32 against symbol `_Py_FalseStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(fileio.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(bytesio.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(bufferedio.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(textio.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(stringio.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(zipimport.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(faulthandler.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(_tracemalloc.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(hashtable.o): relocation R_X86_64_32 against symbol `PyMem_RawFree' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(symtablemodule.o): relocation R_X86_64_32 against symbol `PyUnicode_FSDecoder' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(xxsubtype.o): relocation R_X86_64_32 against `.data' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(getbuildinfo.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(acceler.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(grammar1.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(myreadline.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(parsetok.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(tokenizer.o): relocation R_X86_64_32S against symbol `PyUnicode_Type' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(accu.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(bytes_methods.o): relocation R_X86_64_32S against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(cellobject.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(classobject.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(codeobject.o): relocation R_X86_64_32S against symbol `PyUnicode_Type' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(complexobject.o): relocation R_X86_64_32 against `.data' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(descrobject.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(enumobject.o): relocation R_X86_64_32 against `.data' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(genobject.o): relocation R_X86_64_32 against symbol `_Py_NoneStruct' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(odictobject.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(namespaceobject.o): relocation R_X86_64_32S against symbol `_PyNamespace_Type' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(Python-ast.o): relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(ast.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(ast_opt.o): relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(ast_unparse.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(getcopyright.o): relocation R_X86_64_32 against `.rodata' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(getplatform.o): relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(mystrtoul.o): relocation R_X86_64_32S against symbol `_Py_ctype_table' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(structmember.o): relocation R_X86_64_32S against `.rodata' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(getopt.o): relocation R_X86_64_32S against `.rodata.str4.4' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: /app/.heroku/python/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.a(parser.o): relocation R_X86_64_32 against `.rodata.str1.8' can not be used when making a PIE object; recompile with -fPIC
           /usr/bin/ld: final link failed: Nonrepresentable section on output
           collect2: error: ld returned 1 exit status
           *** error linking uWSGI ***
           
           ----------------------------------------
       Command "/app/.heroku/python/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-5rqpa5d9/uWSGI/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-y9w4kurf-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-5rqpa5d9/uWSGI/
 !     Push rejected, failed to compile Python app.
 !     Push failed
```